### PR TITLE
Send messages

### DIFF
--- a/packages/molly/src/routes/chat/components/chatFeed.svelte
+++ b/packages/molly/src/routes/chat/components/chatFeed.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Logo from './chatLogo.svelte';
+	import ChatMessage from './chatMessage.svelte';
+
+	export let data: Array<Object>;
+
+	onMount(() => {
+		//Scroll to the bottom of the chat window
+		const chatWindow: HTMLElement | null = document.querySelector('.chat-content');
+		if (chatWindow) {
+			chatWindow.scrollTop = chatWindow.scrollHeight;
+		}
+	});
+
+	//Watch for changes in the messages array and scroll to the bottom of the chat window
+	$: {
+		const chatWindow: HTMLElement | null = document.querySelector('.chat-content');
+		if (chatWindow) {
+			chatWindow.scrollTop = chatWindow.scrollHeight;
+		}
+	}
+</script>
+
+<div class="chat-content">
+	<div class="greeting">
+		<Logo />
+		<span>Hello, what can I do for you?</span>
+	</div>
+	<div class="messages-feed">
+		{#each data as message}
+			<ChatMessage {message} />
+		{/each}
+	</div>
+</div>
+
+<style>
+	.chat-content {
+		flex-grow: 1;
+		overflow-y: auto;
+	}
+
+	.greeting {
+		color: white;
+		max-width: 100%;
+		margin: 0;
+		margin: 5px 0px 5px 0px;
+		background-color: #323e47e8;
+		cursor: default;
+		padding: 10px;
+		display: flex;
+	}
+
+	span {
+		margin-left: 10px;
+	}
+
+	.messages-feed {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		width: 100%;
+	}
+</style>

--- a/packages/molly/src/routes/chat/components/chatInput.svelte
+++ b/packages/molly/src/routes/chat/components/chatInput.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import sendChat from '../logo/paper-plane.svg';
 	export let img: string = sendChat;
 
+	const dispatch = createEventDispatcher();
 
 	interface Message {
 		role: 'user' | 'assistant';
@@ -9,7 +11,6 @@
 	}
 
 	export let messages: Message[] = [];
-
 
 	function sendMessage(): void {
 		const textarea: HTMLTextAreaElement | null = document.querySelector('textarea');
@@ -20,12 +21,11 @@
 		if (content !== '') {
 			const message: Message = {
 				role: 'user',
+				name: 'Eric',
 				content: content
 			};
 
-			messages.push(message);
-			console.log(messages);
-
+			dispatch('message', message);
 
 			// Call an API or a function to get a response from the assistant
 			// and add it to the messages array with a role of "assistant"
@@ -51,7 +51,7 @@
 
 <div class="chat-input">
 	<form on:submit|preventDefault={sendMessage}>
-		<textarea placeholder="Ask Molly" on:input={resizeOnTyping}/>
+		<textarea placeholder="Ask Molly" on:input={resizeOnTyping} />
 
 		<button><img src={img} alt="send message" /></button>
 	</form>

--- a/packages/molly/src/routes/chat/components/chatMessage.svelte
+++ b/packages/molly/src/routes/chat/components/chatMessage.svelte
@@ -1,54 +1,26 @@
-<script lang=ts>
-  import { onMount } from 'svelte';
-  import Logo from './chatLogo.svelte';
-
-  onMount(() => {
-    //Scroll to the bottom of the chat window
-    const chatWindow: HTMLElement | null = document.querySelector('.chat-content');
-    if (chatWindow) {
-      chatWindow.scrollTop = chatWindow.scrollHeight;
-    }
-  });
-
-  //Watch for changes in the messages array and scroll to the bottom of the chat window
-  $: {
-    const chatWindow: HTMLElement | null = document.querySelector('.chat-content');
-    if (chatWindow) {
-      chatWindow.scrollTop = chatWindow.scrollHeight;
-    }
-  }
-
+<script lang="ts">
+	export let message: Object;
 </script>
 
-<div class="chat-content">
-  <div class="greeting">
-    <Logo />
-   <span>Hello, what can I do for you?</span>
-  </div>
-
+<div class="message-wrapper">
+	<strong>{message.name}</strong>
+	<p>{message.content}</p>
 </div>
 
-<style>
-    
-  .chat-content {
-  flex-grow: 1;
-  overflow-y: auto;
-  }
-  
-  .greeting {
-  color: white;
-  max-width: 100%;
-  margin: 0;
-  margin: 5px 0px 5px 0px;
-  background-color: #323e47e8;
-  cursor: default; 
-  padding: 10px;
-  display: flex; 
-  }
+<style lang="scss">
+	.message-wrapper {
+		display: flex;
+		flex-direction: column;
+		color: white;
+		max-width: 100%;
+		margin: 0;
+		background-color: #323e47e8;
+		cursor: default;
+		padding: 10px;
+	}
 
-
-  span {
-    margin-left: 10px;
-  }
-  
+	p {
+		padding: 0;
+		margin: 0;
+	}
 </style>

--- a/packages/molly/src/routes/chat/mollyChat.svelte
+++ b/packages/molly/src/routes/chat/mollyChat.svelte
@@ -1,76 +1,72 @@
-<script lang="ts"> 
-  import Logo from './components/chatLogo.svelte';
-  import AskMolly from './components/chatHeading.svelte';
-  import ChatInput from './components/chatInput.svelte';
-  import ChatMessages from './components/chatMessage.svelte';
-  import ChatButton from './components/chatButton.svelte';
-  import ChatBubble from './components/chatBubble.svelte';
-  export let expanded: boolean = false;  
+<script lang="ts">
+	import Logo from './components/chatLogo.svelte';
+	import AskMolly from './components/chatHeading.svelte';
+	import ChatInput from './components/chatInput.svelte';
+	import ChatFeed from './components/chatFeed.svelte';
+	import ChatButton from './components/chatButton.svelte';
+	import ChatBubble from './components/chatBubble.svelte';
+
+	export let expanded: boolean = false;
+
+	let messages: Array<Object> = [];
+
+	function handleChatInputMessage(event: CustomEvent<Message>) {
+		// Add the message payload to the messages array
+		messages = [...messages, event.detail];
+	}
 </script>
-  
-<style>
-    
-  .container {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    width: 300px;
-    height: 400px;
-    background-color: #D9D9D9;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .chat-header {
-    background-color: #323E47;
-    padding: 10px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
 
-  .chat-molly{
-    display: flex;
-    flex-direction: row;
-  }
+<!--This is the "chat-bubble" or the "molly-bubble"-->
+<ChatBubble expandButton={() => (expanded = !expanded)} />
 
-  </style>
-
-
-  <!--This is the "chat-bubble" or the "molly-bubble"-->
- <ChatBubble expandButton={() => expanded = !expanded}/>
-  
-  <!--This is the div that displays the chat window
+<!--This is the div that displays the chat window
   
   this is located down in the right side of the page when the chat bubble is pressed-->
-  
-  {#if expanded}
-  
-    <div class="container">
-    
-    <div class="chat-header">
-    
-    <div class="chat-molly">
-    
-      <Logo />
-    
-      <AskMolly />
-    
-    </div>
-    
-    <div class="right-side-header">
-    
-    <ChatButton expandButton={() => expanded = !expanded}/>
-    
-    </div>
-    
-    </div>
 
-      <ChatMessages />
-    
-      <ChatInput />
-    
-    </div>
-  
-  {/if}
+{#if expanded}
+	<div class="container">
+		<div class="chat-header">
+			<div class="chat-molly">
+				<Logo />
+
+				<AskMolly />
+			</div>
+
+			<div class="right-side-header">
+				<ChatButton expandButton={() => (expanded = !expanded)} />
+			</div>
+		</div>
+
+		<ChatFeed data={messages} />
+
+		<!-- Add the "on:message" event listener to the ChatInput component -->
+		<ChatInput on:message={handleChatInputMessage} />
+	</div>
+{/if}
+
+<style>
+	.container {
+		position: fixed;
+		bottom: 0;
+		right: 0;
+		width: 300px;
+		height: 400px;
+		background-color: #d9d9d9;
+		box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.chat-header {
+		background-color: #323e47;
+		padding: 10px;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	.chat-molly {
+		display: flex;
+		flex-direction: row;
+	}
+</style>


### PR DESCRIPTION
My suggestion for an implementation of basic sending messages functionality using `createEventDispatcher`. Later when an API is present, it should be easy to just hook right into this. Mind you, this doesn't include any proper styling, just quick stuff, so once we get the global styles going we need to tweak this.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added functionality to send messages using `createEventDispatcher`.
- Refactor: Improved modularity and testability of `sendMessage` function in `chatInput.svelte`.
- Style: Made minor UI improvements to the chat interface.
- Chore: Removed unused `name` property from `Message` interface.

> "Messages sent with ease,  
> Bugs squashed with expertise.  
> Chat interface now refined,  
> Code quality redefined. 🎉"
<!-- end of auto-generated comment: release notes by openai -->