### PR TITLE
Updated layout to match most recent wireframe

### DIFF
--- a/packages/lms/src/lib/components/footer/Footer.svelte
+++ b/packages/lms/src/lib/components/footer/Footer.svelte
@@ -1,12 +1,14 @@
 <script lang="ts"></script>
 
-<footer>FOOTER</footer>
+<footer>
+	<slot/>
+</footer>
 
 <style>
 	footer {
 		grid-area: footer;
+		display: flex;
+		gap: 0.5rem;
 		background-color: var(--primary);
-		color: var(--white);
-		padding: var(--spacing-m);
 	}
 </style>

--- a/packages/lms/src/lib/components/header/Header.svelte
+++ b/packages/lms/src/lib/components/header/Header.svelte
@@ -6,5 +6,6 @@
   header {
     grid-area: header;
     display: flex;
+    gap: 0.5rem;
   }
 </style>

--- a/packages/lms/src/lib/components/header/Reader.svelte
+++ b/packages/lms/src/lib/components/header/Reader.svelte
@@ -15,7 +15,6 @@
 	}
 
 	.reader-inner {
-		background-color: var(--background-primary);
 		width: 100%;
 		border-radius: var(--border-radius-xs);
 		margin: 0 auto;

--- a/packages/lms/src/lib/components/header/Search.svelte
+++ b/packages/lms/src/lib/components/header/Search.svelte
@@ -1,0 +1,11 @@
+<form class="search">
+  <input type="search" placeholder="Search" />
+  <button>Search</button>
+</form>
+
+<style>
+  .search {
+    display: flex;
+    flex: 1;
+  }
+</style>

--- a/packages/lms/src/lib/components/ui/Ego.svelte
+++ b/packages/lms/src/lib/components/ui/Ego.svelte
@@ -1,0 +1,18 @@
+<div class="ego">
+  <img src="https://i.imgur.com/8Km9tLL.jpg" alt="Profile image" />
+</div>
+
+<style>
+  .ego {
+    aspect-ratio: 1;
+    height: 100%;
+    overflow: hidden;
+    padding: 0.25rem;
+  }
+
+  img {
+    max-width: 100%;
+    border-radius: 50%;
+    margin: auto;
+  }
+</style>

--- a/packages/lms/src/routes/+layout.svelte
+++ b/packages/lms/src/routes/+layout.svelte
@@ -10,12 +10,14 @@
 	import ContentNav from '$lib/components/navigation/ContentNav.svelte';
 	import IconNav from '$lib/components/navigation/IconNav.svelte';
 	import Header from '$lib/components/header/Header.svelte';
+	import Ego from '$lib/components/ui/Ego.svelte';
+	import Search from '$lib/components/header/Search.svelte';
 </script>
 
 <div class="layout-grid">
 	<Logo />
 	<Header>
-		<Reader />
+		<Search/>
 		<Settings />
 	</Header>
 	<Molly />
@@ -25,7 +27,10 @@
 	</Main>
 	<Navigation />
 	<ContentNav />
-	<Footer />
+	<Footer>
+		<Ego/>
+		<Reader />
+	</Footer>
 </div>
 
 <style lang="scss">
@@ -39,6 +44,5 @@
 			'icons body nav1 nav2'
 			'footer footer footer footer';
 		gap: 0.5rem;
-		padding-right: 1rem;
 	}
 </style>


### PR DESCRIPTION
Updates layout files to bring things close inline with the most recent codepen wireframe. This involves moving the reader to the footer, creating a search and ego component for user profile navigation and for sitewide search. Basic implementations for now.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Updates layout files to match the most recent wireframe, moving the reader to the footer and adding a search and ego component for user profile navigation and sitewide search. The changes include adding a gap of 0.5rem between elements in the header section, updating the footer element to include a slot and flex display with gap, and adding a basic search component to the layout files. Additionally, the diff updates the layout files to match a recent wireframe, moving the reader to the footer and creating search and ego components. The only change in the diff is the removal of a background color property from a CSS rule. These changes are minor and do not affect the code logic or functionality.

> A new layout has arrived,
> With search and ego components to thrive.
> The reader now resides in the footer,
> And gaps between elements make it neater.
<!-- end of auto-generated comment: release notes by openai -->