### PR TITLE
Cli patch

### DIFF
--- a/packages/lms/src/lib/utils/getEntityChildren.ts
+++ b/packages/lms/src/lib/utils/getEntityChildren.ts
@@ -1,13 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 import type { EntityMeta } from '@mollify/types';
-import getEntityMeta from './getEntity';
+import getEntityMeta from './getEntityMeta';
 
 export default function getEntityChildren(entityPath: string): EntityMeta[] {
-  const fullPath = path.resolve(entityPath);
+  let fullPath = path.resolve(entityPath);
 
-  if (!fs.existsSync(fullPath) || !fs.lstatSync(fullPath).isDirectory()) {
-    throw new Error(`Path does not exist or is not a directory: ${fullPath}`);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Path does not exist`);
+  }
+
+  if (!fs.lstatSync(fullPath).isDirectory()) {
+    fullPath = path.dirname(fullPath);
   }
 
   const childPaths = fs.readdirSync(fullPath);

--- a/packages/lms/src/lib/utils/getEntityFrontmatter.ts
+++ b/packages/lms/src/lib/utils/getEntityFrontmatter.ts
@@ -4,16 +4,11 @@ import matter from 'gray-matter';
 import type { EntityBase } from '@mollify/types';
 
 export function getEntityFrontmatter(entityPath: string): EntityBase {
-  const fileName = '+page.md';
-  const contentPath = fs.existsSync(path.join(entityPath, fileName))
-    ? path.join(entityPath, fileName)
-    : entityPath;
-
-  if (!fs.existsSync(contentPath)) {
-    throw new Error(`Content file does not exist: ${contentPath}`);
+  if (!fs.existsSync(entityPath)) {
+    throw new Error(`Content file does not exist: ${entityPath}`);
   }
 
-  const content = fs.readFileSync(contentPath, 'utf-8');
+  const content = fs.readFileSync(entityPath, 'utf-8');
   const { data } = matter(content);
 
   return {

--- a/packages/lms/src/lib/utils/getEntitySlug.ts
+++ b/packages/lms/src/lib/utils/getEntitySlug.ts
@@ -3,10 +3,9 @@ import path from 'path';
 export default function getEntitySlug(address: string): string {
   const fullPath = path.resolve(address);
   const pageFileName = '+page.md';
-  const contentPath = path.join(fullPath, pageFileName);
 
   if (!fullPath.endsWith(pageFileName)) {
-    throw new Error(`Entity file does not have the expected file name: ${contentPath}`);
+    throw new Error(`Entity file does not have the expected file name: ${fullPath} [${pageFileName}]`);
   }
 
   const entityFolder = path.dirname(fullPath);


### PR DESCRIPTION
Normalises behaviour so that Entity.address can always be used to get entity meta data. Previously some of these functions expected the parent folder name instead.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Refactor: Modify behavior of `getEntityChildren`, `getEntityFrontmatter`, and `getEntitySlug` functions to improve consistency and error handling.

> "Code changes abound,
> Logic and functionality found,
> Bugs and vulnerabilities unbound,
> With these changes, let's astound!"
<!-- end of auto-generated comment: release notes by openai -->