### PR TITLE
Patch tts file replacement

### DIFF
--- a/packages/lms/src/lib/components/header/Reader.svelte
+++ b/packages/lms/src/lib/components/header/Reader.svelte
@@ -83,7 +83,7 @@
 		}
 
 		const filepath = path;
-		const data = await createAudio(content, slug, filepath, true);
+		const data = await createAudio(content, slug, filepath, hasAudio);
 		audio.set(data);
 		audioSrc = data.url;
 		isloading = false;
@@ -100,6 +100,7 @@
 				background: 'variant-filled-success',
 				autohide: false
 			};
+			hasAudio = true;
 			toastStore.trigger(userFeedback);
 		}
 	}

--- a/packages/tts/lib/generateAudio.ts
+++ b/packages/tts/lib/generateAudio.ts
@@ -28,7 +28,7 @@ export async function generateAudio(content: string, slug: string, filepath: str
 
     if (response.ok) {
       // Delete existing file if it already exists
-      if (replace) {
+      if (replace && fs.existsSync(filePath)) {
         console.log("file deleted");
         fs.unlinkSync(filePath);
       }


### PR DESCRIPTION
Minor fixes to tts, as when creating a new file on a lesson without audio it was trying to delete a non-existent file, due to the reader incorrectly always having replace set to true.