### PR TITLE
Patch resizer prose bug

### DIFF
--- a/packages/lms/src/lib/components/header/Reader.svelte
+++ b/packages/lms/src/lib/components/header/Reader.svelte
@@ -83,7 +83,7 @@
 		}
 
 		const filepath = path;
-		const data = await createAudio(content, slug, filepath, true);
+		const data = await createAudio(content, slug, filepath, hasAudio);
 		audio.set(data);
 		audioSrc = data.url;
 		isloading = false;
@@ -100,6 +100,7 @@
 				background: 'variant-filled-success',
 				autohide: false
 			};
+			hasAudio = true;
 			toastStore.trigger(userFeedback);
 		}
 	}

--- a/packages/tts/lib/generateAudio.ts
+++ b/packages/tts/lib/generateAudio.ts
@@ -28,7 +28,7 @@ export async function generateAudio(content: string, slug: string, filepath: str
 
     if (response.ok) {
       // Delete existing file if it already exists
-      if (replace) {
+      if (replace && fs.existsSync(filePath)) {
         console.log("file deleted");
         fs.unlinkSync(filePath);
       }


### PR DESCRIPTION
Re-arrange tailwind config to import skeleton ui css first, to prevent duplicate prose rule overwriting prose sizing rules for the text resizer. Commented out code on the resize, a more indepth refactor is needed to remove all un-needed code.