### PR TITLE
Refactors keyboard navigation code block

### DIFF
--- a/packages/cli/src/tsconfig.json
+++ b/packages/cli/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "outDir": "bin",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "bin"]
+}

--- a/packages/lms/src/lib/components/header/Search.svelte
+++ b/packages/lms/src/lib/components/header/Search.svelte
@@ -1,194 +1,183 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { getSearchResults } from '$lib/utils/fuseSearch/getSearchResults';
-	import { parseRawSearchQuery } from '$lib/utils/fuseSearch/parseRawSearchQuery';
+  import { goto } from '$app/navigation';
+  import { getSearchResults } from '$lib/utils/fuseSearch/getSearchResults';
+  import { parseRawSearchQuery } from '$lib/utils/fuseSearch/parseRawSearchQuery';
 
-	let searchQuery = '';
-	let searchResults: { label: string; value: string; refIndex: number; browserPath: string }[] = [];
-	let timer: string | number | NodeJS.Timeout | undefined;
-	let inputFocused = false;
-	let returnedResults = false;
-	let rawQuery = '';
+  let searchQuery = '';
+  let searchResults: { label: string; value: string; refIndex: number; browserPath: string }[] = [];
+  let timer: string | number | NodeJS.Timeout | undefined;
+  let inputFocused = false;
+  let returnedResults = false;
+  let rawQuery = '';
 
-	//these handle keyboard navigation
-	//set to -1 so that the user can select the first search suggestion which in an array would be 0
-	let selection: number = -1;
-	let pathToNavigateTo: string = '';
+  //these handle keyboard navigation
+  //set to -1 so that the user can select the first search suggestion which in an array would be 0
+  let selection: number = -1;
+  let pathToNavigateTo: string = '';
 
-	interface SearchResultItem {
-		title: string;
-		slug: string;
-		refIndex: number;
-	}
+  interface SearchResultItem {
+    title: string;
+    slug: string;
+    refIndex: number;
+  }
 
-	function handleSubmit(event: { preventDefault: () => void }) {
-		if (pathToNavigateTo === '') {
-			goto(`/search?query=${encodeURIComponent(searchQuery)}`);
-		} else {
-			goto(pathToNavigateTo);
-		}
-		searchQuery = '';
-		selection = -1;
-	}
+  function handleSubmit(event: { preventDefault: () => void }) {
+    if (pathToNavigateTo === '') {
+      goto(`/search?query=${encodeURIComponent(searchQuery)}`);
+    } else {
+      goto(pathToNavigateTo);
+    }
+    searchQuery = '';
+    selection = -1;
+  }
 
-	const debounceSearch = async () => {
-		clearTimeout(timer);
-		returnedResults = false;
-		if (searchQuery.length) {
-			await new Promise((resolve) => {
-				timer = setTimeout(async () => {
-					try {
-						const { query, filters } = parseRawSearchQuery(searchQuery);
-						rawQuery = query;
-						let results = await getSearchResults(query, filters);
-						searchResults = results.map((result: SearchResultItem) => {
-							const { title, slug, ...other } = result;
-							return { label: title, value: slug, ...other };
-						});
-						console.log(query, filters);
-						console.log('results', searchResults);
-					} catch (error) {
-						console.log(error);
-					}
-				}, 500);
-			});
-		} else {
-			searchResults = [];
-		}
-	};
+  const debounceSearch = async () => {
+    clearTimeout(timer);
+    returnedResults = false;
+    if (searchQuery.length) {
+      await new Promise((resolve) => {
+        timer = setTimeout(async () => {
+          try {
+            const { query, filters } = parseRawSearchQuery(searchQuery);
+            rawQuery = query;
+            let results = await getSearchResults(query, filters);
+            searchResults = results.map((result: SearchResultItem) => {
+              const { title, slug, ...other } = result;
+              return { label: title, value: slug, ...other };
+            });
+            console.log(query, filters);
+            console.log('results', searchResults);
+          } catch (error) {
+            console.log(error);
+          }
+        }, 500);
+      });
+    } else {
+      searchResults = [];
+    }
+  };
 
-	function handleKeyboardNavigation(event: KeyboardEvent): void {
-		const key = event.key;
+  function handleKeyboardNavigation(event: KeyboardEvent): void {
+    const key = event.key;
 
-		switch (key) {
-			case 'ArrowDown':
-				navigateSearchResults(1);
-				break;
-			case 'ArrowUp':
-				navigateSearchResults(-1);
-				break;
-			case 'Backspace':
-			case 'Delete':
-				if (searchQuery === '') {
-					selection = -1;
-				}
-				break;
-			default:
-				break;
-		}
-	}
+    switch (key) {
+      case 'ArrowDown':
+        navigateSearchResults(1);
+        break;
+      case 'ArrowUp':
+        navigateSearchResults(-1);
+        break;
+      case 'Backspace':
+      case 'Delete':
+        if (searchQuery === '') {
+          selection = -1;
+        }
+        break;
+      default:
+        break;
+    }
+  }
 
-	function navigateSearchResults(direction: number): void {
-		//selects the search result
-		const newSelection = selection + direction;
-		if (newSelection >= 0 && newSelection < searchResults.length) {
-			selection = newSelection;
-		}
-		//styles the selected search result
-		const selectedSuggestion = searchResults[selection].refIndex;
-		searchResults.forEach((result) => {
-			const domElement = document.getElementById(result.refIndex.toString());
-			result.refIndex === selectedSuggestion
-				? domElement?.classList.add('bg-primary-300/25')
-				: domElement?.classList.remove('bg-primary-300/25');
-			//scrolls down if selected element isn't in view
-			if (domElement && domElement?.offsetTop > 140) {
-				result.refIndex === selectedSuggestion &&
-					domElement?.scrollIntoView({
-						behavior: 'smooth',
-						block: 'nearest',
-						inline: 'start'
-					});
-			}
-			//scrolls up if selected element isn't in view
-			if (domElement && domElement?.offsetTop < 140) {
-				result.refIndex === selectedSuggestion &&
-					domElement?.scrollIntoView({
-						behavior: 'smooth',
-						block: 'nearest',
-						inline: 'start'
-					});
-			}
+  function navigateSearchResults(direction: number): void {
+    //selects the search result
+    const newSelection = selection + direction;
+    if (newSelection >= 0 && newSelection < searchResults.length) {
+      selection = newSelection;
+    }
+    //styles the selected search result
+    const selectedSuggestion = searchResults[selection].refIndex;
+    searchResults.forEach((result) => {
+      const domElement = document.getElementById(result.refIndex.toString());
+      result.refIndex === selectedSuggestion
+        ? domElement?.classList.add('bg-primary-300/25')
+        : domElement?.classList.remove('bg-primary-300/25');
+      //scrolls up/down if selected element isn't in view
+      result.refIndex === selectedSuggestion &&
+        domElement?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'start'
+        });
 
-			if (result.refIndex === selectedSuggestion) {
-				pathToNavigateTo = result.browserPath;
-			}
-		});
-	}
+      if (result.refIndex === selectedSuggestion) {
+        pathToNavigateTo = result.browserPath;
+      }
+    });
+  }
 
-	function handlePageChange() {
-		setTimeout(() => {
-			searchResults = [];
-			searchQuery = '';
-			selection = -1;
-		}, 10);
-	}
+  function handlePageChange() {
+    setTimeout(() => {
+      searchResults = [];
+      searchQuery = '';
+      selection = -1;
+    }, 10);
+  }
 
-	function handleClickOutside(event: MouseEvent | TouchEvent) {
-		const target = event.target as Element;
+  function handleClickOutside(event: MouseEvent | TouchEvent) {
+    const target = event.target as Element;
 
-		if (!target.closest('.wrapper') && !target.closest('.search-items')) {
-			handlePageChange();
-		}
-	}
+    if (!target.closest('.wrapper') && !target.closest('.search-items')) {
+      handlePageChange();
+    }
+  }
 
-	function handleSearchSelection(path: string) {
-		goto(path);
-	}
+  function handleSearchSelection(path: string) {
+    goto(path);
+  }
 
   $: searchResults;
 </script>
 
 <svelte:window on:click={handleClickOutside} />
 <div class="max-w-sm relative">
-	<form
-		class="flex w-full sm:input-group sm:input-group-divider sm:grid-cols-[auto_1fr_auto]"
-		on:submit|preventDefault={handleSubmit}
-	>
-		<input
-			class="input hidden sm:block w-60"
-			type="search"
-			name="autocomplete-search"
-			placeholder="Search markdown content"
-			autocomplete="off"
-			bind:value={searchQuery}
-			on:input={async () => {
-				debounceSearch();
-			}}
-			on:focus={() => {
-				inputFocused = true;
-			}}
-			on:blur={() => {
-				inputFocused = false;
-			}}
-			on:keyup={handleKeyboardNavigation}
-		/>
-		<button
-			class="btn hover:bg-primary-hover-token sm:variant-filled-primary sm:rounded-l-none sm:hover:bg-primary-active-token"
-			><i class="icon-f">search</i></button
-		>
-	</form>
-	{#if searchResults.length > 0}
-		<dl class="list-dl w-full max-h-48 p-4 overflow-y-auto absolute bg-surface-100-800-token">
-			{#each searchResults as item, i}
-				<div
-					id={item.refIndex.toString()}
-					class="hover:bg-primary-hover-token rounded-container-token cursor-pointer"
-					on:click={() => {
-						handleSearchSelection(item.browserPath);
-					}}
-					on:keyup={handleKeyboardNavigation}
-				>
-					<span class="flex-auto w-full fill-current transition-transform duration-[200ms]">
-						<dt class="truncate">{item.label}</dt>
-					</span>
-				</div>
-			{/each}
-		</dl>
-	{/if}
-	{#if searchResults.length === 0 && inputFocused && searchQuery.length >= 3 && returnedResults}
-		<div class="card w-full max-h-48 p-4 overflow-y-auto absolute">
-			<p>No Results Found</p>
-		</div>
-	{/if}
+  <form
+    class="flex w-full sm:input-group sm:input-group-divider sm:grid-cols-[auto_1fr_auto]"
+    on:submit|preventDefault={handleSubmit}
+  >
+    <input
+      class="input hidden sm:block w-60"
+      type="search"
+      name="autocomplete-search"
+      placeholder="Search markdown content"
+      autocomplete="off"
+      bind:value={searchQuery}
+      on:input={async () => {
+        debounceSearch();
+      }}
+      on:focus={() => {
+        inputFocused = true;
+      }}
+      on:blur={() => {
+        inputFocused = false;
+      }}
+      on:keyup={handleKeyboardNavigation}
+    />
+    <button
+      class="btn hover:bg-primary-hover-token sm:variant-filled-primary sm:rounded-l-none sm:hover:bg-primary-active-token"
+      ><i class="icon-f">search</i></button
+    >
+  </form>
+  {#if searchResults.length > 0}
+    <dl class="list-dl w-full max-h-48 p-4 overflow-y-auto absolute bg-surface-100-800-token">
+      {#each searchResults as item, i}
+        <div
+          id={item.refIndex.toString()}
+          class="hover:bg-primary-hover-token rounded-container-token cursor-pointer"
+          on:click={() => {
+            handleSearchSelection(item.browserPath);
+          }}
+          on:keyup={handleKeyboardNavigation}
+        >
+          <span class="flex-auto w-full fill-current transition-transform duration-[200ms]">
+            <dt class="truncate">{item.label}</dt>
+          </span>
+        </div>
+      {/each}
+    </dl>
+  {/if}
+  {#if searchResults.length === 0 && inputFocused && searchQuery.length >= 3 && returnedResults}
+    <div class="card w-full max-h-48 p-4 overflow-y-auto absolute">
+      <p>No Results Found</p>
+    </div>
+  {/if}
 </div>

--- a/packages/lms/src/routes/+layout.svelte
+++ b/packages/lms/src/routes/+layout.svelte
@@ -13,15 +13,13 @@
   import 'prismjs/themes/prism-tomorrow.css';
   import type { LayoutData } from './$types';
   import EntityNav from '$lib/components/navigation/EntityNav.svelte';
-  import { afterNavigate } from '$app/navigation';
+  import { page } from '$app/stores';
 
   export let data: LayoutData;
-	let main: Main;
 
-	afterNavigate(() => {
-		main?.scrollToTop();
-	})
-
+  const scrollIntoView = (node: HTMLElement) => {
+    node.scrollIntoView();
+  };
 </script>
 
 <Drawer>
@@ -42,7 +40,10 @@
   <svelte:fragment slot="sidebarLeft">
     <IconNav />
   </svelte:fragment>
-  <Main bind:this={main}>
+  {#key $page.url.pathname}
+    <div use:scrollIntoView />
+  {/key}
+  <Main>
     <slot />
   </Main>
   <svelte:fragment slot="footer"


### PR DESCRIPTION
I made a minor improvement to the `navigateSearchResults()`. Previously, the function attempted to scroll the selected search result into view by checking its position in the DOM and then scrolling based on that position. I had logged the position to the console to check if the element was visible or not, and hardcoded the position in an if statement to implement the functionality. That obviously wasn't a perfect approach since any changes to the search bar's placement in the DOM would have broken the scrolling behaviour.

However, I realised that I didn't need the position at all. I removed the if statements, and now the scrolling into view is handled by one small block of code that scrolls up or down, as opposed to the previous two separate blocks for scrolling up and down.

It looks like I've made more changes than I actually did, but they're only indentation.