### PR TITLE
158 undefined nav items

### DIFF
--- a/packages/lms/src/lib/components/navigation/Entity.svelte
+++ b/packages/lms/src/lib/components/navigation/Entity.svelte
@@ -13,7 +13,7 @@
     Assessment: 'task',
     Lesson: 'article',
     Module: 'layers',
-    Course: 'book_5',
+    Course: 'book',
     Programme: 'folder',
     Institution: 'school'
   };

--- a/packages/lms/src/lib/components/navigation/Entity.svelte
+++ b/packages/lms/src/lib/components/navigation/Entity.svelte
@@ -10,16 +10,16 @@
   let typeOfEntity = entity.type;
 
   const entityIcons = {
-    Assessment: 'Task',
-    Lesson: 'Article',
-    Module: 'Layers',
-    Course: 'Book_5',
-    Programme: 'Folder',
-    Institution: 'School'
+    Assessment: 'task',
+    Lesson: 'article',
+    Module: 'layers',
+    Course: 'book_5',
+    Programme: 'folder',
+    Institution: 'school'
   };
-  let icon = entityIcons[typeOfEntity] || 'Folder';
+  let icon = entityIcons[typeOfEntity] || 'folder';
   if (entity.children.length === 0 && !entityIcons[typeOfEntity]) {
-    icon = 'Article';
+    icon = 'article';
   }
 
   function toggle() {
@@ -30,10 +30,18 @@
 <nav class="entity">
   <div class="entity-inner">
     <div class="entity-header hover:bg-primary-hover-token rounded-container-token p-2">
-      <a href={entity.browserPath} on:click={drawerClose} class="entity-title flex flex-row items-center">
-        <Icon name={icon} />
-        <p>{entity.title}</p>
-      </a>
+      {#if entity.browserPath}
+        <a href={entity.browserPath} on:click={drawerClose} class="entity-title flex flex-row items-center">
+          <Icon name={icon} />
+          <p class="ms-2">{entity.title}</p>
+        </a>
+      {:else}
+        <button on:click={toggle} class="entity-title flex flex-row items-center">
+          <Icon name={icon} />
+          <span class="ms-2 text-start">{entity.title}</span>
+        </button>
+      {/if}
+
       {#if entity.children.length}
         <button on:click={toggle} class="btn hover:bg-primary-hover-token p-0">
           <Icon name={open ? 'expand_less' : 'expand_more'} />


### PR DESCRIPTION
This should fix issue #158 

Additional checks added to added to getEntityMetaTree function
- Checks entire file tree for .md files before adding it to children
- If a folder has no .md file but has folders within it the folder name is use for the title.

Updated Entity component
- Icon names switched to lower case due to rendering issues
- Added if check for nav items with no .md file these are rendered as button and not links.