### PR TITLE
174 add prop variant to iconsvelte

### DIFF
--- a/packages/lms/src/lib/components/ui/Icon.svelte
+++ b/packages/lms/src/lib/components/ui/Icon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let name: string;
-  export let variant:string = "";
+  export let variant = "";
   import 'material-icons/iconfont/material-icons.css';
 </script>
 <!-- Default variant is "filled". Please give variant type (outlined/round/sharp/two-tone) as prop if you want to change-->

--- a/packages/lms/src/lib/components/ui/Icon.svelte
+++ b/packages/lms/src/lib/components/ui/Icon.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let name: string;
+  export let variant:string;
   import 'material-icons/iconfont/material-icons.css';
 </script>
 
-<span class="material-icons" {...$$restProps}>{name}</span>
+<span class={variant? `material-icons-${variant}`: 'material-icons'} {...$$restProps}>{name}</span>

--- a/packages/lms/src/lib/components/ui/Icon.svelte
+++ b/packages/lms/src/lib/components/ui/Icon.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   export let name: string;
-  export let variant:string;
+  export let variant:string = "";
   import 'material-icons/iconfont/material-icons.css';
 </script>
-
+<!-- Default variant is "filled". Please give variant type (outlined/round/sharp/two-tone) as prop if you want to change-->
+<!-- https://www.npmjs.com/package/material-icons#usage -->
 <span class={variant? `material-icons-${variant}`: 'material-icons'} {...$$restProps}>{name}</span>


### PR DESCRIPTION
Added variant prop in Icon component. 
At the moment we are using only filled variant(default), but we have now options to change the variant. 

Please refer [#174](https://github.com/Fermain/-mollify/issues/174)
