### PR TITLE
Add aria-labels and titles to icon btns & logo

### DIFF
--- a/packages/lms/src/lib/components/bookmarks/icons/AddRemoveBookmarks.svelte
+++ b/packages/lms/src/lib/components/bookmarks/icons/AddRemoveBookmarks.svelte
@@ -35,15 +35,23 @@
 </script>
 
 <div>
-  <button
-    name="tile-2"
-    class="app-rail-tile unstyled grid place-content-center place-items-center w-full aspect-square space-y-1.5 cursor-pointer bg-primary-hover-token"
-    on:click={() => onclick()}
-  >
-    {#if hasBookmarks}
-      <Icon name="bookmark_remove" />
-    {:else}
-      <Icon name="bookmark_add" />
-    {/if}
-  </button>
+  {#if hasBookmarks}
+    <button
+      name="tile-2"
+      class="app-rail-tile unstyled grid place-content-center place-items-center w-full aspect-square space-y-1.5 cursor-pointer bg-primary-hover-token"
+      on:click={() => onclick()}
+      aria-label="remove bookmark"
+    >
+      <Icon name="bookmark_remove" title="remove bookmark" />
+    </button>
+  {:else}
+    <button
+      name="tile-2"
+      class="app-rail-tile unstyled grid place-content-center place-items-center w-full aspect-square space-y-1.5 cursor-pointer bg-primary-hover-token"
+      on:click={() => onclick()}
+      aria-label="add bookmark"
+    >
+      <Icon name="bookmark_add" title="add bookmark" /></button
+    >
+  {/if}
 </div>

--- a/packages/lms/src/lib/components/bookmarks/icons/Bookmarks.svelte
+++ b/packages/lms/src/lib/components/bookmarks/icons/Bookmarks.svelte
@@ -22,8 +22,9 @@
     name="tile-2"
     class="app-rail-tile unstyled grid place-content-center place-items-center w-full aspect-square space-y-1.5 cursor-pointer bg-primary-hover-token"
     on:click={() => modalStore.trigger(searchModal)}
+    aria-label="open bookmarks"
   >
-    <Icon name="bookmark" />
+    <Icon name="bookmark" title="bookmarks" />
   </button>
 
   <Modal components={modalComponent} />

--- a/packages/lms/src/lib/components/header/Header.svelte
+++ b/packages/lms/src/lib/components/header/Header.svelte
@@ -17,8 +17,8 @@
   <Search />
   <svelte:fragment slot="trail">
     <Settings />
-    <button class="lg:hidden btn btn-sm mr-4 hover:bg-primary-hover-token" on:click={drawerOpen}>
-      <Icon name="menu" />
+    <button class="lg:hidden btn btn-sm mr-4 hover:bg-primary-hover-token" on:click={drawerOpen} aria-label="open menu">
+      <Icon name="menu" title="menu" />
     </button>
   </svelte:fragment>
 </AppBar>

--- a/packages/lms/src/lib/components/header/Logo.svelte
+++ b/packages/lms/src/lib/components/header/Logo.svelte
@@ -1,4 +1,4 @@
-<a href="/"
+<a href="/" aria-label="Back to Home" title="Home"
   ><svg
     width="100%"
     height="100%"

--- a/packages/lms/src/lib/components/header/Search.svelte
+++ b/packages/lms/src/lib/components/header/Search.svelte
@@ -155,8 +155,9 @@
     />
     <button
       class="btn hover:bg-primary-hover-token sm:variant-filled-primary sm:rounded-l-none sm:hover:bg-primary-active-token"
+      aria-label="search"
     >
-      <Icon name="search" /></button
+      <Icon name="search" title="search" /></button
     >
   </form>
   {#if searchResults.length > 0}

--- a/packages/lms/src/lib/components/header/Settings.svelte
+++ b/packages/lms/src/lib/components/header/Settings.svelte
@@ -44,7 +44,9 @@
 </script>
 
 <div>
-  <button class="btn hover:bg-primary-hover-token" use:popup={settings}> <Icon name="settings" /></button>
+  <button class="btn hover:bg-primary-hover-token" use:popup={settings} aria-label="settings">
+    <Icon name="settings" title="settings" /></button
+  >
 
   <div class="card p-4 w-60 shadow-xl" data-popup="settings" id="settings-card">
     <h3 class="h3 mb-3">Settings</h3>
@@ -56,21 +58,39 @@
     <div class="flex justify-between my-5">
       <span class="p-1">Text</span>
       <div class="flex gap-4">
-        <button class="btn hover:bg-primary-hover-token p-1" on:click={fontSize.increaseFontSize}>
-          <Icon name="text_increase" /></button
+        <button
+          class="btn hover:bg-primary-hover-token p-1"
+          on:click={fontSize.increaseFontSize}
+          aria-label="increase font size"
         >
-        <button class="btn hover:bg-primary-hover-token p-1" on:click={fontSize.decreaseFontSize}>
-          <Icon name="text_decrease" /></button
+          <Icon name="text_increase" title="text increase" /></button
         >
-        <button class="btn hover:bg-primary-hover-token p-1" on:click={fontSize.resetFontSize}>
-          <Icon name="refresh" /></button
+        <button
+          class="btn hover:bg-primary-hover-token p-1"
+          on:click={fontSize.decreaseFontSize}
+          aria-label="decrease font size"
+        >
+          <Icon name="text_decrease" title="text decrease" /></button
+        >
+        <button
+          class="btn hover:bg-primary-hover-token p-1"
+          on:click={fontSize.resetFontSize}
+          aria-label="reset font size"
+        >
+          <Icon name="refresh" title="reset" /></button
         >
       </div>
     </div>
     <div class="flex justify-between my-5">
       <span class="p-1">Word emphasis</span>
       <div class="flex gap-4">
-        <SlideToggle name="slide" size="sm" on:click={toggleWordEmphasis} checked={$wordEmphasisEnabled} />
+        <SlideToggle
+          name="slide"
+          size="sm"
+          on:click={toggleWordEmphasis}
+          checked={$wordEmphasisEnabled}
+          aria-label="toggle word emphasis"
+        />
       </div>
     </div>
   </div>

--- a/packages/lms/src/lib/components/navigation/Entity.svelte
+++ b/packages/lms/src/lib/components/navigation/Entity.svelte
@@ -56,7 +56,7 @@
         {/if}
         {#if entity.children.length}
           <button on:click={toggle} class="btn hover:bg-primary-hover-token p-0">
-            <Icon name={open ? 'expand_less' : 'expand_more'} />
+            <Icon name={open ? 'expand_less' : 'expand_more'} title={open ? 'hide' : 'expand'} />
           </button>
         {/if}
       </div>

--- a/packages/lms/src/lib/components/reader/Reader.svelte
+++ b/packages/lms/src/lib/components/reader/Reader.svelte
@@ -124,7 +124,9 @@
 <div class="flex w-full justify-between items-center">
   {#if path.startsWith('/content')}
     <div>
-      <button class="btn hover:bg-primary-hover-token" use:popup={audioSettings}> <Icon name="hearing" /></button>
+      <button class="btn hover:bg-primary-hover-token" use:popup={audioSettings} aria-label="Open audio setting">
+        <Icon name="hearing" title="Audio Setting" /></button
+      >
       <div class="card p-4 w-60 shadow-xl" data-popup="audioSettings" id="settings-card">
         <h3 class="h3 mb-3">Audio Settings</h3>
         <hr />

--- a/packages/lms/src/lib/components/ui/Icon.svelte
+++ b/packages/lms/src/lib/components/ui/Icon.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   export let name: string;
   export let variant = '';
+  export let title = '';
   import 'material-icons/iconfont/material-icons.css';
 </script>
 
 <!-- Default variant is "filled". Please give variant type (outlined/round/sharp/two-tone) as prop if you want to change-->
 <!-- https://www.npmjs.com/package/material-icons#usage -->
-<span class={variant ? `material-icons-${variant}` : 'material-icons'} {...$$restProps}>{name}</span>
+<span class={variant ? `material-icons-${variant}` : 'material-icons'} {...$$restProps} {title}>{name}</span>

--- a/packages/molly/src/lib/components/MollyHeader.svelte
+++ b/packages/molly/src/lib/components/MollyHeader.svelte
@@ -13,7 +13,7 @@
     on:click={toggleExpand}
     aria-label="resize chat box"
   >
-    <img src={img} alt="resize" class="h-5 w-5 m-auto" />
+    <img src={img} alt="resize" class="h-5 w-5 m-auto" title="resize chat box" />
   </button>
   <button on:click={toggleMollyOpen} class="btn-icon drop-shadow-md hover:drop-shadow-lg" aria-label="hide chat box">
     <Logo />

--- a/packages/molly/src/lib/components/MollyIcon.svelte
+++ b/packages/molly/src/lib/components/MollyIcon.svelte
@@ -2,4 +2,4 @@
   import img from './icons/molly_logo.png';
 </script>
 
-<img src={img} alt="Molly logo" class="rounded-full" />
+<img src={img} alt="Molly logo" class="rounded-full" title="open/close Molly" />


### PR DESCRIPTION
Added aria-lables and titles to icon buttons and logo/Home button to improve accessibility.

When the user hovers over an icon button, a tool tip shows what it is for. 