### PR TITLE
Remove 100vh from toc

### DIFF
--- a/packages/lms/src/lib/styles/_toc.scss
+++ b/packages/lms/src/lib/styles/_toc.scss
@@ -2,7 +2,7 @@
   position: sticky;
   top: 1rem;
   overflow-y: auto;
-  height: calc(100vh - 10rem);
+  padding-bottom: 2rem;
 
   &-label {
     display: none;


### PR DESCRIPTION
Removed 100vh from table of content and added some padding. 
Now toc should not take up all the screen height. 